### PR TITLE
Added dpkg, and code to get architecture from print-architecture command

### DIFF
--- a/root/etc/cont-init.d/90-sma-config
+++ b/root/etc/cont-init.d/90-sma-config
@@ -15,6 +15,7 @@ else
         wget \
         python3 \
         python3-pip \
+        dpkg
         git > /dev/null
     python3 -m pip install -q --user --upgrade pip
     python3 -m pip install -q --user virtualenv --no-warn-script-location
@@ -35,7 +36,7 @@ then
 else
     # check ffmpeg URL
     if [[ -z "${SMA_FFMPEG_URL}" ]]; then
-    architecture=$(dpkg --print-architecture)
+    architecture=$(dpkg --print-architecture | awk -F'-' '{print $NF}' )
     case "$architecture" in
         'amd64')
         export SMA_FFMPEG_URL="https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz"


### PR DESCRIPTION
dpkg --print-architecture returns musl-linux-amd64...thanks to https://github.com/tianon/gosu/issues/24 I was able to find this bit of awk magic that should fix that. Testing the rest of the script